### PR TITLE
Fixed integer overflow when buying accessories

### DIFF
--- a/engine/src/main/java/de/oglimmer/cyc/api/Establishment.java
+++ b/engine/src/main/java/de/oglimmer/cyc/api/Establishment.java
@@ -110,26 +110,17 @@ public class Establishment implements IEstablishment {
 		buyInteriorAccessories(iaToAdd);
 	}
 
-	private int calcTotalCost(Collection<InteriorAccessory> iaToAdd) {
-		int total = 0;
-		for (InteriorAccessory intAcc : iaToAdd) {
-			total += intAcc.getAssetCost();
-		}
-		return total;
-	}
-
 	private void buyInteriorAccessories(Collection<InteriorAccessory> iaToAdd) {
-		int total = calcTotalCost(iaToAdd);
-		if (parent.getCash() >= total) {
-			try {
-				parent.decCash(total);
-				parent.getGame().getResult().getCreateNotExists(parent.getName()).addTotalInterior(total);
-				for (InteriorAccessory ia : iaToAdd) {
+		for (InteriorAccessory ia : iaToAdd) {
+			if (parent.getCash() >= ia.getAssetCost()) {
+				try {
+					parent.decCash(ia.getAssetCost());
+					parent.getGame().getResult().getCreateNotExists(parent.getName()).addTotalInterior(ia.getAssetCost());
 					interiorAccessories.add(ia);
 					log.debug(parent.getName() + " bought " + ia + " for " + getAddress());
+				} catch (OutOfMoneyException e) {
+					log.debug("Company " + e.getCompany() + " is bankrupt");
 				}
-			} catch (OutOfMoneyException e) {
-				log.debug("Company " + e.getCompany() + " is bankrupt");
 			}
 		}
 	}

--- a/engine/src/test/java/de/oglimmer/cyc/api/EstablishmentTest.java
+++ b/engine/src/test/java/de/oglimmer/cyc/api/EstablishmentTest.java
@@ -1,12 +1,13 @@
 package de.oglimmer.cyc.api;
 
-import java.util.Iterator;
-
+import de.oglimmer.cyc.DataBackendMemory;
+import de.oglimmer.cyc.api.Constants.Mode;
 import org.junit.Assert;
 import org.junit.Test;
 
-import de.oglimmer.cyc.DataBackendMemory;
-import de.oglimmer.cyc.api.Constants.Mode;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Iterator;
 
 public class EstablishmentTest {
 
@@ -147,6 +148,23 @@ public class EstablishmentTest {
 			day++;
 		}
 
+	}
+
+	@Test
+	public void testInteriorAccessoriesIntegerOverflow() {
+		Game game = new Game(Mode.FULL, DataBackendMemory.INSTANCE);
+		Company company = new Company(game, "companyA", game.getGrocer());
+		Establishment est = new Establishment(company, "cityA", 5, 50, 1000, 2000);
+		company.getEstablishmentsInt().add(est);
+		ThreadLocal.setCompany(company);
+
+		ArrayList<String> accessories = new ArrayList<>(429498 * 2);
+		for (int i = 0; i < 429498 * 2; i++) {
+			accessories.add(InteriorAccessory.OVEN.toString());
+		}
+		est.buyInteriorAccessories(accessories.toArray(new String[0]));
+
+		Assert.assertNotEquals(accessories.size(), est.getInteriorAccessories().size());
 	}
 
 }

--- a/engine/src/test/java/de/oglimmer/cyc/api/EstablishmentTest.java
+++ b/engine/src/test/java/de/oglimmer/cyc/api/EstablishmentTest.java
@@ -5,7 +5,6 @@ import de.oglimmer.cyc.api.Constants.Mode;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Iterator;
 


### PR DESCRIPTION
By buying a large enough list of accessories, a player is able to obtain accessories for free. This is fixed by this commit, though it changes the semantics of buyInteriorAccessories(). Before, if there was not enough cash to buy everything from the list, nothing will be bought. Now, items from the list will be bought in order until the company runs out of cash.